### PR TITLE
Add help modal and info tooltips to legal search UI

### DIFF
--- a/legalai-ui/client/components/HelpModal.tsx
+++ b/legalai-ui/client/components/HelpModal.tsx
@@ -1,0 +1,140 @@
+import { useState } from "react";
+import { HelpCircle, Search, FileText, Sparkles, Bookmark } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+
+interface HelpModalProps {
+  triggerClassName?: string;
+  context?: "search" | "case-detail";
+}
+
+export function HelpModal({
+  triggerClassName = "",
+  context = "search",
+}: HelpModalProps) {
+  const [open, setOpen] = useState(false);
+
+  const searchHelp = (
+    <div className="space-y-6">
+      <div className="space-y-3">
+        <div className="flex items-center gap-2">
+          <Search className="h-5 w-5 text-primary" />
+          <h3 className="text-lg font-semibold">How to Search</h3>
+        </div>
+        <ul className="space-y-2 text-sm text-muted-foreground">
+          <li>• Enter keywords, case names, or legal concepts</li>
+          <li>• Use quotation marks for exact phrases: "reasonable doubt"</li>
+          <li>• Combine terms with AND/OR: "contract AND breach"</li>
+          <li>• Use filters to narrow down by court, year, or citations</li>
+        </ul>
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex items-center gap-2">
+          <FileText className="h-5 w-5 text-primary" />
+          <h3 className="text-lg font-semibold">Understanding Results</h3>
+        </div>
+        <ul className="space-y-2 text-sm text-muted-foreground">
+          <li>• Results are ranked by relevance to your search</li>
+          <li>• Citation count shows how often the case is referenced</li>
+          <li>• Click any case to view the full judgment</li>
+          <li>• Use filters to refine your search results</li>
+        </ul>
+      </div>
+    </div>
+  );
+
+  const caseDetailHelp = (
+    <div className="space-y-6">
+      <div className="space-y-3">
+        <div className="flex items-center gap-2">
+          <FileText className="h-5 w-5 text-primary" />
+          <h3 className="text-lg font-semibold">Reading Judgments</h3>
+        </div>
+        <ul className="space-y-2 text-sm text-muted-foreground">
+          <li>• Full judgment text is displayed with proper formatting</li>
+          <li>
+            • Use your browser's search (Ctrl/Cmd + F) to find specific terms
+          </li>
+          <li>• Scroll through the document to read the complete case</li>
+          <li>• Citation count shows legal importance and precedent value</li>
+        </ul>
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex items-center gap-2">
+          <Sparkles className="h-5 w-5 text-primary" />
+          <h3 className="text-lg font-semibold">AI Summarization</h3>
+        </div>
+        <ul className="space-y-2 text-sm text-muted-foreground">
+          <li>• Click "Summarize Case" to get an AI-generated summary</li>
+          <li>• Summaries highlight key facts, legal issues, and decisions</li>
+          <li>• Use summaries to quickly understand case relevance</li>
+          <li>• Always read the full text for complete understanding</li>
+        </ul>
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex items-center gap-2">
+          <Bookmark className="h-5 w-5 text-primary" />
+          <h3 className="text-lg font-semibold">Navigation</h3>
+        </div>
+        <ul className="space-y-2 text-sm text-muted-foreground">
+          <li>• Use "Back to Results" to return to your search</li>
+          <li>• Your search results and filters will be preserved</li>
+          <li>• Bookmark important cases for later reference</li>
+        </ul>
+      </div>
+    </div>
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          className={`flex items-center gap-2 ${triggerClassName}`}
+        >
+          <HelpCircle className="h-4 w-4" />
+          Help
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <HelpCircle className="h-5 w-5 text-primary" />
+            How to Use Maamla Legal Hai
+          </DialogTitle>
+          <DialogDescription>
+            Learn how to search and explore Indian legal cases effectively
+          </DialogDescription>
+        </DialogHeader>
+
+        {context === "search" ? searchHelp : caseDetailHelp}
+
+        <div className="mt-6 p-4 bg-legal-blue-light/30 rounded-lg border">
+          <h4 className="font-semibold text-legal-blue mb-2">💡 Pro Tips</h4>
+          <ul className="space-y-1 text-sm text-muted-foreground">
+            <li>• Start with broad terms, then use filters to narrow down</li>
+            <li>• Check citation counts to find landmark cases</li>
+            <li>• Use AI summaries to quickly assess case relevance</li>
+            <li>• Combine multiple search terms for better results</li>
+          </ul>
+        </div>
+
+        <div className="flex justify-end mt-4">
+          <Button onClick={() => setOpen(false)}>Got it!</Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/legalai-ui/client/components/InfoTooltip.tsx
+++ b/legalai-ui/client/components/InfoTooltip.tsx
@@ -1,0 +1,32 @@
+import { Info } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+interface InfoTooltipProps {
+  content: string | React.ReactNode;
+  className?: string;
+}
+
+export function InfoTooltip({ content, className = "" }: InfoTooltipProps) {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            className={`inline-flex items-center justify-center w-5 h-5 rounded-full bg-muted hover:bg-muted-foreground/20 transition-colors ${className}`}
+            aria-label="Help information"
+          >
+            <Info className="h-3 w-3 text-muted-foreground" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" className="max-w-sm">
+          <div className="text-sm">{content}</div>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/legalai-ui/client/components/SearchBar.tsx
+++ b/legalai-ui/client/components/SearchBar.tsx
@@ -25,27 +25,49 @@ export function SearchBar({
   };
 
   return (
-    <div className="relative flex w-full max-w-4xl mx-auto">
-      <div className="relative flex-1">
-        <Search className="absolute left-4 top-1/2 transform -translate-y-1/2 text-muted-foreground h-5 w-5" />
-        <Input
-          type="text"
-          placeholder={placeholder}
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          onKeyPress={handleKeyPress}
-          className="pl-12 pr-4 py-6 text-lg border-2 border-border focus:border-primary transition-colors"
-          disabled={isLoading}
+    <div className="space-y-2">
+      <div className="flex items-center justify-center gap-2">
+        <h2 className="text-xl font-semibold text-center">
+          Search Legal Cases
+        </h2>
+        <InfoTooltip
+          content={
+            <div className="space-y-2">
+              <p>
+                <strong>Search Tips:</strong>
+              </p>
+              <ul className="text-xs space-y-1">
+                <li>• Use specific legal terms or case names</li>
+                <li>• Try "contract breach" or "criminal appeal"</li>
+                <li>• Use filters below to narrow results</li>
+                <li>• Quotation marks for exact phrases</li>
+              </ul>
+            </div>
+          }
         />
       </div>
-      <Button
-        onClick={onSearch}
-        disabled={isLoading || !value.trim()}
-        size="lg"
-        className="ml-3 px-8 py-6 text-lg font-medium"
-      >
-        {isLoading ? "Searching..." : "Search"}
-      </Button>
+      <div className="relative flex w-full max-w-4xl mx-auto">
+        <div className="relative flex-1">
+          <Search className="absolute left-4 top-1/2 transform -translate-y-1/2 text-muted-foreground h-5 w-5" />
+          <Input
+            type="text"
+            placeholder={placeholder}
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            onKeyPress={handleKeyPress}
+            className="pl-12 pr-4 py-6 text-lg border-2 border-border focus:border-primary transition-colors"
+            disabled={isLoading}
+          />
+        </div>
+        <Button
+          onClick={onSearch}
+          disabled={isLoading || !value.trim()}
+          size="lg"
+          className="ml-3 px-8 py-6 text-lg font-medium"
+        >
+          {isLoading ? "Searching..." : "Search"}
+        </Button>
+      </div>
     </div>
   );
 }

--- a/legalai-ui/client/components/SearchBar.tsx
+++ b/legalai-ui/client/components/SearchBar.tsx
@@ -1,6 +1,7 @@
 import { Search } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { InfoTooltip } from "./InfoTooltip";
 
 interface SearchBarProps {
   value: string;

--- a/legalai-ui/client/pages/CaseDetail.tsx
+++ b/legalai-ui/client/pages/CaseDetail.tsx
@@ -78,7 +78,12 @@ export default function CaseDetailPage() {
   };
 
   const handleBack = () => {
-    navigate(-1);
+    // If we have search state, navigate back to search page with restored state
+    if (location.state?.searchState) {
+      navigate("/", { state: { searchState: location.state.searchState } });
+    } else {
+      navigate(-1);
+    }
   };
 
   const handleSummarize = async () => {

--- a/legalai-ui/client/pages/CaseDetail.tsx
+++ b/legalai-ui/client/pages/CaseDetail.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate, useLocation } from "react-router-dom";
 import {
   ArrowLeft,
   Calendar,
@@ -57,7 +57,7 @@ export default function CaseDetailPage() {
     } catch (err) {
       console.error("Error fetching case detail:", err);
       setError(
-        err instanceof Error ? err.message : "Failed to load case details"
+        err instanceof Error ? err.message : "Failed to load case details",
       );
     } finally {
       setIsLoading(false);

--- a/legalai-ui/client/pages/CaseDetail.tsx
+++ b/legalai-ui/client/pages/CaseDetail.tsx
@@ -248,21 +248,6 @@ export default function CaseDetailPage() {
             />
           </CardContent>
         </Card>
-
-        {/* Summarize Button and Summary */}
-        <Button
-          onClick={handleSummarize}
-          disabled={isSummarizing}
-          className="mb-4"
-        >
-          {isSummarizing ? "Summarizing..." : "Summarize"}
-        </Button>
-        {summary && (
-          <div className="prose dark:prose-invert my-4 p-4 border rounded bg-muted/30">
-            <strong>Summary:</strong>
-            <div>{summary}</div>
-          </div>
-        )}
       </div>
     </div>
   );

--- a/legalai-ui/client/pages/CaseDetail.tsx
+++ b/legalai-ui/client/pages/CaseDetail.tsx
@@ -30,6 +30,7 @@ function transformCaseDetail(raw: any): CaseDetail {
 export default function CaseDetailPage() {
   const { docid } = useParams<{ docid: string }>();
   const navigate = useNavigate();
+  const location = useLocation();
   const [caseDetail, setCaseDetail] = useState<CaseDetail | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);

--- a/legalai-ui/client/pages/CaseDetail.tsx
+++ b/legalai-ui/client/pages/CaseDetail.tsx
@@ -203,9 +203,35 @@ export default function CaseDetailPage() {
                   <span>Published {formatDate(caseDetail.publish_date)}</span>
                 </div>
               </div>
+
+              {/* Summarize Button at the top */}
+              <div className="pt-4 border-t">
+                <Button
+                  onClick={handleSummarize}
+                  disabled={isSummarizing}
+                  size="lg"
+                  className="bg-legal-blue hover:bg-legal-blue/90"
+                >
+                  {isSummarizing ? "Summarizing..." : "✨ Summarize Case"}
+                </Button>
+              </div>
             </div>
           </CardHeader>
         </Card>
+
+        {/* Summary Display */}
+        {summary && (
+          <Card className="mb-8 bg-legal-blue-light/30 border-legal-blue/20">
+            <CardHeader>
+              <CardTitle className="text-lg text-legal-blue">
+                Case Summary
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="prose dark:prose-invert">{summary}</div>
+            </CardContent>
+          </Card>
+        )}
 
         {/* Case Content */}
         <Card>

--- a/legalai-ui/client/pages/Index.tsx
+++ b/legalai-ui/client/pages/Index.tsx
@@ -107,7 +107,17 @@ export default function Index() {
   };
 
   const handleViewDetails = (docid: string) => {
-    navigate(`/case/${docid}`);
+    // Pass current search state so it can be restored on back navigation
+    navigate(`/case/${docid}`, {
+      state: {
+        searchState: {
+          searchQuery,
+          filters,
+          results,
+          hasSearched,
+        },
+      },
+    });
   };
 
   const handleClearFilters = () => {

--- a/legalai-ui/client/pages/Index.tsx
+++ b/legalai-ui/client/pages/Index.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useState, useEffect } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
 import { Scale } from "lucide-react";
 import { SearchBar } from "@/components/SearchBar";
 import { FilterSection, FilterValues } from "@/components/FilterSection";
@@ -9,11 +9,11 @@ import type { CaseResult, SearchRequest } from "@shared/api";
 
 const initialFilters: FilterValues = {
   courtTypes: [],
-  year: "", 
+  year: "",
   maxCitations: "",
   title: "",
   author: "",
-  bench: ""
+  bench: "",
 };
 
 export default function Index() {
@@ -81,7 +81,7 @@ export default function Index() {
       setError(
         err instanceof Error
           ? err.message
-          : "An error occurred while searching"
+          : "An error occurred while searching",
       );
       setResults([]);
     } finally {
@@ -185,8 +185,7 @@ export default function Index() {
         <div className="container mx-auto px-4 py-8">
           <div className="text-center text-sm text-muted-foreground">
             <p>
-              © 2025 Maamla Legal Hai. Search Indian legal cases and
-              judgments.
+              © 2025 Maamla Legal Hai. Search Indian legal cases and judgments.
             </p>
             <p className="mt-2">
               This platform provides access to legal information for research

--- a/legalai-ui/client/pages/Index.tsx
+++ b/legalai-ui/client/pages/Index.tsx
@@ -18,12 +18,29 @@ const initialFilters: FilterValues = {
 
 export default function Index() {
   const navigate = useNavigate();
+  const location = useLocation();
   const [searchQuery, setSearchQuery] = useState("");
   const [filters, setFilters] = useState<FilterValues>(initialFilters);
   const [results, setResults] = useState<CaseResult[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [hasSearched, setHasSearched] = useState(false);
+
+  // Restore search state from navigation state
+  useEffect(() => {
+    if (location.state?.searchState) {
+      const {
+        searchQuery: prevQuery,
+        filters: prevFilters,
+        results: prevResults,
+        hasSearched: prevHasSearched,
+      } = location.state.searchState;
+      setSearchQuery(prevQuery);
+      setFilters(prevFilters);
+      setResults(prevResults);
+      setHasSearched(prevHasSearched);
+    }
+  }, [location.state]);
 
   const handleSearch = async () => {
     if (!searchQuery.trim()) return;


### PR DESCRIPTION
This PR adds help functionality to the legal search interface:

**New Components:**
- `HelpModal.tsx`: Context-aware help modal with search and case detail guidance
- `InfoTooltip.tsx`: Reusable tooltip component for inline help

**Enhanced Components:**
- `SearchBar.tsx`: Added search tips tooltip and improved layout with title
- `CaseDetail.tsx`: Moved summarize button to top, improved summary display styling
- `Index.tsx`: Added navigation state preservation for back button functionality

**Key Features:**
- Context-sensitive help content for search vs case detail pages
- Search tips and pro tips in help modal
- Improved case summary presentation with better styling
- State preservation when navigating between search results and case details
- Better visual hierarchy with search title and inline help tooltips

The help modal provides comprehensive guidance on search techniques, result interpretation, AI summarization, and navigation patterns.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/024b81620789414da7685780922dd5de/quantum-zone)

👀 [Preview Link](https://024b81620789414da7685780922dd5de-quantum-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>024b81620789414da7685780922dd5de</projectId>-->
<!--<branchName>quantum-zone</branchName>-->