### PR TITLE
Add pagination caching to prevent redundant API calls

### DIFF
--- a/legalai-ui/client/pages/Index.tsx
+++ b/legalai-ui/client/pages/Index.tsx
@@ -391,7 +391,7 @@ export default function Index() {
             error={error}
             searchQuery={hasSearched ? searchQuery : ""}
             onViewDetails={handleViewDetails}
-            onPageChange={handleSearch}
+            onPageChange={handlePageChange}
           />
         </section>
       </main>

--- a/legalai-ui/client/pages/Index.tsx
+++ b/legalai-ui/client/pages/Index.tsx
@@ -17,6 +17,15 @@ const initialFilters: FilterValues = {
   bench: "",
 };
 
+// Cache structure for pagination results
+interface SearchCache {
+  [searchKey: string]: {
+    pages: { [page: number]: CaseResult[] };
+    pagination: PaginationInfo | null;
+    filters: FilterValues;
+  };
+}
+
 export default function Index() {
   const navigate = useNavigate();
   const location = useLocation();
@@ -27,7 +36,9 @@ export default function Index() {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [hasSearched, setHasSearched] = useState(false);
+  const [currentPage, setCurrentPage] = useState(0);
   const searchSectionRef = useRef<HTMLDivElement>(null);
+  const searchCache = useRef<SearchCache>({});
 
   // Restore search state from navigation state or localStorage
   useEffect(() => {

--- a/legalai-ui/client/pages/Index.tsx
+++ b/legalai-ui/client/pages/Index.tsx
@@ -287,6 +287,7 @@ export default function Index() {
           results,
           pagination,
           hasSearched,
+          currentPage,
         },
       },
     });
@@ -295,6 +296,13 @@ export default function Index() {
   const handleClearFilters = () => {
     setFilters(initialFilters);
   };
+
+  // Clear cache when filters change (except on initial load)
+  useEffect(() => {
+    if (hasSearched) {
+      clearCacheForSearch();
+    }
+  }, [filters]);
 
   const courtTypeMap: Record<string, string> = {
     "Supreme Court of India": "supremecourt",

--- a/legalai-ui/client/pages/Index.tsx
+++ b/legalai-ui/client/pages/Index.tsx
@@ -94,12 +94,14 @@ export default function Index() {
         results: prevResults,
         pagination: prevPagination,
         hasSearched: prevHasSearched,
+        currentPage: prevCurrentPage = 0,
       } = location.state.searchState;
       setSearchQuery(prevQuery);
       setFilters(prevFilters);
       setResults(prevResults);
       setPagination(prevPagination || null);
       setHasSearched(prevHasSearched);
+      setCurrentPage(prevCurrentPage);
     } else {
       // Try to restore from localStorage
       try {

--- a/legalai-ui/client/pages/Index.tsx
+++ b/legalai-ui/client/pages/Index.tsx
@@ -113,12 +113,14 @@ export default function Index() {
             results: prevResults,
             pagination: prevPagination,
             hasSearched: prevHasSearched,
+            currentPage: prevCurrentPage = 0,
           } = JSON.parse(savedState);
           setSearchQuery(prevQuery || "");
           setFilters(prevFilters || initialFilters);
           setResults(prevResults || []);
           setPagination(prevPagination || null);
           setHasSearched(prevHasSearched || false);
+          setCurrentPage(prevCurrentPage);
         }
       } catch (error) {
         console.log("Failed to restore search state:", error);


### PR DESCRIPTION
## Purpose

The user identified that pagination was making fresh API calls for every page navigation, including when returning to previously visited pages. This was inefficient as it was re-fetching data that had already been loaded, resulting in unnecessary network requests and slower user experience.

## Code changes

- **Added search result caching system**: Implemented `SearchCache` interface and cache management functions to store pagination results in memory
- **Cache key generation**: Created `generateSearchKey()` to uniquely identify searches based on query and filters
- **Cache operations**: Added `isPageCached()`, `getCachedPage()`, and `cachePage()` functions to manage cached data
- **Separate page change handler**: Created `handlePageChange()` that checks cache first before making API calls
- **Cache invalidation**: Added logic to clear cache when search query or filters change
- **State persistence**: Updated localStorage to include current page information for proper state restoration
- **Navigation state**: Enhanced navigation state to preserve current page across route changes

The implementation ensures that previously visited pages are served from cache, while new searches and filter changes properly invalidate the cache to maintain data accuracy.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 16`

🔗 [Edit in Builder.io](https://builder.io/app/projects/024b81620789414da7685780922dd5de/neon-den)

👀 [Preview Link](https://024b81620789414da7685780922dd5de-neon-den.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>024b81620789414da7685780922dd5de</projectId>-->
<!--<branchName>neon-den</branchName>-->